### PR TITLE
fix: PGDATA directory in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgai_data:/var/lib/postgresql/data
+      - pgai_data:/home/postgres/pgdata/data
       - ./init-db:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]


### PR DESCRIPTION
The PGDATA directory for the `timescaledb-ha` image is `/home/postgres/pgdata/data`. When set to `/var/lib/postgresql/data` (the PGDATA directory for the `timescaledb` image), table data will not persist across runs.

See: https://docs.timescale.com/self-hosted/latest/install/installation-docker/